### PR TITLE
Change tooltip arrow direction & scrollTop z-index

### DIFF
--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -1,21 +1,5 @@
 @import '~bootstrap/scss/bootstrap';
 
-.wrapper-messages {
-  pointer-events: none;
-}
-
-.message-success {
-  background-color: rgba(92,184,92, 0.85);
-  color: rgb(2,34,2);
-  pointer-events: auto;
-}
-
-.message-failed {
-  background-color: rgba(217, 83, 79, 0.85);
-  color: rgb(97, 3, 0);
-  pointer-events: auto;
-}
-
 .deleteMessage {
   font-size: 18px;
   justify-content: flex-start;
@@ -31,6 +15,7 @@
   color: white;
   background: rgba(52, 58, 64, 0.5);
   line-height: 45px;
+  z-index: 9999;
 }
 
 .scroll-to-top:focus,

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
                     <label for="createItemPrice">Price</label>
                     <input name="item[price]" type="number" class="form-control" min="0" step=".01" id="createItemPrice" aria-describedby="emailHelp" placeholder="Price Per Unit">
                   </div>
-                  <div class="form-group" data-toggle="tooltip" data-placement="top" title="Threshold is the quanitity at which reorder status becomes urgent. When quantity reaches 150% of the threshold amount, reorder status will turn yellow - indicating it is time to reorder. When the quantity reaches the threshold amount, reorder status will turn red for that item - indicating reorder urgency.">
+                  <div class="form-group" data-toggle="tooltip" data-placement="bottom" title="Threshold is the quanitity at which reorder status becomes urgent. When quantity reaches 150% of the threshold amount, reorder status will turn yellow - indicating it is time to reorder. When the quantity reaches the threshold amount, reorder status will turn red for that item - indicating reorder urgency.">
                     <label for="createItemThreshold">Threshold</label>
                     <input name="item[limit]" type="number" class="form-control" min="0" id="createItemThreshold" aria-describedby="emailHelp" placeholder="Threshold">
                   </div>
@@ -78,7 +78,7 @@
                     <label for="updateItemPrice">Price</label>
                     <input name="item[price]" type="number" class="form-control" id="updateItemPrice" min="0" step=".01" aria-describedby="emailHelp" placeholder="Price Per Unit">
                   </div>
-                  <div class="form-group" data-toggle="tooltip" data-placement="top" title="Threshold is the quanitity at which reorder status becomes urgent. When quantity reaches 150% of the threshold amount, reorder status will turn yellow - indicating it is time to reorder. When the quantity reaches the threshold amount, reorder status will turn red for that item - indicating reorder urgency.">
+                  <div class="form-group" data-toggle="tooltip" data-placement="bottom" title="Threshold is the quanitity at which reorder status becomes urgent. When quantity reaches 150% of the threshold amount, reorder status will turn yellow - indicating it is time to reorder. When the quantity reaches the threshold amount, reorder status will turn red for that item - indicating reorder urgency.">
                     <label for="updateItemThreshold">Threshold</label>
                     <input name="item[limit]" type="number" class="form-control" min="0" id="updateItemThreshold" aria-describedby="emailHelp" placeholder="Threshold">
                   </div>


### PR DESCRIPTION
1. Arrows moved from top to bottom of threshold tooltips so that they
point toward the correct field.
2. Gave scrollTop button a z-index of 9999 so that it is not hidden by
sidebar.
3. Moved sign-in.css to styles folder and made corresponding change to
html head.